### PR TITLE
Add API Endpoint to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Set the following [environment variables within Insomnia](https://support.insomn
     - More information on generating and downloading private keys for your GitHub Apps is [available in the documentation](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#generating-a-private-key)
 1. <kbd>github_app_installation_id</kbd>: The ID for an installation of your GitHub App
     - Found using [the `GET /app/installations`](https://developer.github.com/v3/apps/#find-installations) API endpoint
+1. <kbd>github_api_root</kbd>: The API Root for your GitHub App
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports.templateTags = [
     ],
     async run({ context }, ...args) {
       // Destructure id, path from context
-      let { github_app_id: id, github_app_private_key_path: path, github_api_root: githubApiRoot } = context;
+      let { github_app_id: id, github_app_private_key_path: path, github_api_root: githubApiRoot = 'https://api.github.com' } = context;
 
       // Allow id, path to be overridden via args
       const [tagId = 0, tagPath = ''] = args;

--- a/index.js
+++ b/index.js
@@ -18,19 +18,28 @@ module.exports.templateTags = [
         displayName: 'Private key file',
         description: 'Path to private key file in PEM format',
         type: 'string'
+      },
+      {
+        displayName: 'GitHub API Root',
+        description: 'The base URL to which to send requests',
+        type: 'string'
       }
     ],
     async run({ context }, ...args) {
       // Destructure id, path from context
-      let { github_app_id: id, github_app_private_key_path: path } = context;
+      let { github_app_id: id, github_app_private_key_path: path, github_api_root: githubApiRoot } = context;
 
       // Allow id, path to be overridden via args
       const [tagId = 0, tagPath = ''] = args;
       id = tagId > 0 ? tagId : id;
       path = tagPath.length > 0 ? tagPath : path;
 
-      // Instatiate App with id, path
-      const app = new App({ id, privateKey: getPrivateKey(path) });
+      // Instatiate App with id, path, apiRoot
+      const app = new App({
+        id,
+        privateKey: getPrivateKey(path),
+        baseUrl: githubApiRoot
+      });
 
       // Return JWT
       return app.getSignedJsonWebToken();
@@ -56,6 +65,11 @@ module.exports.templateTags = [
         displayName: 'Private key file',
         description: 'Path to private key file in PEM format',
         type: 'string'
+      },
+      {
+        displayName: 'GitHub API Root',
+        description: 'The base URL to which to send requests',
+        type: 'string'
       }
     ],
     async run({ context }, ...args) {
@@ -63,7 +77,8 @@ module.exports.templateTags = [
       let {
         github_app_installation_id: installationId,
         github_app_id: id,
-        github_app_private_key_path: path
+        github_app_private_key_path: path,
+        github_api_root: githubApiRoot,
       } = context;
 
       // Allow installationId, id, path to be overridden via args
@@ -72,8 +87,12 @@ module.exports.templateTags = [
       id = tagId > 0 ? tagId : id;
       path = tagPath.length > 0 ? tagPath : path;
 
-      // Instatiate App with id, path
-      const app = new App({ id, privateKey: getPrivateKey(path) });
+      // Instatiate App with id, path, apiRoot
+      const app = new App({
+        id,
+        privateKey: getPrivateKey(path),
+        baseUrl: githubApiRoot,
+      });
 
       // Return installation access token
       return app.getCachedInstallationAccessToken({ installationId });


### PR DESCRIPTION
This allows Insomnia to work with non-github.com installations, like GitHub Enterprise or running locally.

This works off of the `github_api_root` provided by https://git.io/github-rest-apis-for-insomnia

cc @swinton 